### PR TITLE
FlashSound get_duration reporting insanely long duration.

### DIFF
--- a/src/flambe/platform/flash/FlashSound.hx
+++ b/src/flambe/platform/flash/FlashSound.hx
@@ -37,7 +37,7 @@ class FlashSound
 
     public function get_duration () :Float
     {
-        return nativeSound.length*1000;
+        return nativeSound.length/1000;
     }
 }
 


### PR DESCRIPTION
Just need to divide instead of multiply. :)
