### PR TITLE
First-pass fixes for HXSL 2.0

### DIFF
--- a/bin/build-chxdoc
+++ b/bin/build-chxdoc
@@ -16,7 +16,7 @@ rm -rf "$CHXDOC_DIR"
 cd "$TMP_DIR"
 haxe -xml haxedoc.xml -debug \
     --macro 'include("flambe", true, ["flambe.platform"])' \
-    -lib format -cp "$FLAMBE_ROOT/src" \
+    -lib hxsl -cp "$FLAMBE_ROOT/src" \
     -js none.js --no-output
 
 # Generate the actual chxdoc directory

--- a/bin/run-travis
+++ b/bin/run-travis
@@ -17,7 +17,7 @@ export PATH="$FLAMBE_SPACE/bin:$PATH"
 
 echo "Validating compilation..."
 haxe -js out.js --no-output --macro 'include("flambe", true, ["flambe.platform"])' \
-    -lib format -cp "$FLAMBE_SPACE/src"
+    -lib hxsl -cp "$FLAMBE_SPACE/src"
 
 echo "Running unit tests..."
 cd tests

--- a/etc/haxelib.xml
+++ b/etc/haxelib.xml
@@ -5,7 +5,7 @@
     Flambe is a fast, expressive, and cross-platform engine for Flash and HTML5 games.
   </description>
 
-  <depends name="format" version="1.26"/>
+  <depends name="hxsl" version="2.0"/>
   <depends name="air3" version="3.4"/>
 
   <version name="{{VERSION}}">See https://github.com/aduros/flambe/wiki/Changes</version>

--- a/src/flambe/display/Sprite.hx
+++ b/src/flambe/display/Sprite.hx
@@ -535,12 +535,12 @@ class Sprite extends Component
     private static var _scratchPoint = new Point();
 
     // Various flags used by Sprite and subclasses
-    private static inline var VISIBLE = 1 << 0;
-    private static inline var POINTER_ENABLED = 1 << 1;
-    private static inline var LOCAL_MATRIX_DIRTY = 1 << 2;
-    private static inline var VIEW_MATRIX_DIRTY = 1 << 3;
-    private static inline var MOVIESPRITE_PAUSED = 1 << 4;
-    private static inline var TEXTSPRITE_DIRTY = 1 << 5;
+    private static inline var VISIBLE = 1;
+    private static inline var POINTER_ENABLED = 2;
+    private static inline var LOCAL_MATRIX_DIRTY = 4;
+    private static inline var VIEW_MATRIX_DIRTY = 8;
+    private static inline var MOVIESPRITE_PAUSED = 16;
+    private static inline var TEXTSPRITE_DIRTY = 32;
 
     private var _flags :Int;
 

--- a/src/flambe/platform/flash/Stage3DBatcher.hx
+++ b/src/flambe/platform/flash/Stage3DBatcher.hx
@@ -14,13 +14,13 @@ import flash.geom.Matrix3D;
 import flash.geom.Rectangle;
 import flash.geom.Vector3D;
 
-import format.hxsl.Shader;
-
 import flambe.display.BlendMode;
 import flambe.platform.shader.DrawImage;
 import flambe.platform.shader.DrawPattern;
 import flambe.platform.shader.FillRect;
 import flambe.util.Assert;
+
+import hxsl.Shader;
 
 class Stage3DBatcher
 {
@@ -29,9 +29,9 @@ class Stage3DBatcher
     public function new (context3D :Context3D)
     {
         _context3D = context3D;
-        _drawImageShader = new DrawImage(context3D);
-        _drawPatternShader = new DrawPattern(context3D);
-        _fillRectShader = new FillRect(context3D);
+        _drawImageShader = new DrawImage();
+        _drawPatternShader = new DrawPattern();
+        _fillRectShader = new FillRect();
 
         _scratchScissor = new Rectangle();
 
@@ -264,30 +264,27 @@ class Stage3DBatcher
         }
 
         var vertexBuffer = null;
-        switch (_lastShader) {
-        case cast _drawImageShader:
-            _drawImageShader.init({}, {texture: _lastTexture.nativeTexture});
+        if(Std.is(_lastShader, DrawImage)) {
+            _drawImageShader.texture = _lastTexture.nativeTexture;
             vertexBuffer = _vertexBuffer5;
-
-        case cast _drawPatternShader:
+        } else if(Std.is(_lastShader, DrawPattern)) {
             var maxUV = _scratchVector3D;
             maxUV.x = _lastTexture.maxU;
             maxUV.y = _lastTexture.maxV;
             // maxUV.z = 0;
             // maxUV.w = 0;
-            _drawPatternShader.init({}, {texture: _lastTexture.nativeTexture, maxUV: maxUV});
+            _drawPatternShader.texture = _lastTexture.nativeTexture;
+            _drawPatternShader.maxUV = maxUV;
             vertexBuffer = _vertexBuffer5;
-
-        case cast _fillRectShader:
-            _fillRectShader.init({}, {});
+        } else if(Std.is(_lastShader, FillRect)) {
             vertexBuffer = _vertexBuffer6;
         }
 
         // vertexBuffer.uploadFromVector(data, 0, _quads*4);
         vertexBuffer.uploadFromVector(data, 0, _maxQuads*4);
-        _lastShader.bind(vertexBuffer);
+        _lastShader.bind(_context3D, vertexBuffer);
         _context3D.drawTriangles(_quadIndexBuffer, 0, _quads*2);
-        _lastShader.unbind();
+        _lastShader.unbind(_context3D);
 
 #if flambe_debug_renderer
         trace("Flushed " + _quads + " / " + _maxQuads + " quads");

--- a/src/flambe/platform/shader/DrawImage.hx
+++ b/src/flambe/platform/shader/DrawImage.hx
@@ -4,7 +4,7 @@
 
 package flambe.platform.shader;
 
-import format.hxsl.Shader;
+import hxsl.Shader;
 
 /**
  * Shader that draws textured triangles with a given alpha.
@@ -22,9 +22,9 @@ class DrawImage extends Shader
         var _alpha :Float;
 
         function vertex () {
-            _uv = uv;
-            _alpha = alpha;
-            out = pos.xyzw;
+            _uv = input.uv;
+            _alpha = input.alpha;
+            out = input.pos.xyzw;
         }
 
         function fragment (texture :Texture) {

--- a/src/flambe/platform/shader/DrawPattern.hx
+++ b/src/flambe/platform/shader/DrawPattern.hx
@@ -4,7 +4,7 @@
 
 package flambe.platform.shader;
 
-import format.hxsl.Shader;
+import hxsl.Shader;
 
 /**
  * Draws a repeating texture.
@@ -22,9 +22,9 @@ class DrawPattern extends Shader
         var _alpha :Float;
 
         function vertex () {
-            _uv = uv;
-            _alpha = alpha;
-            out = pos.xyzw;
+            _uv = input.uv;
+            _alpha = input.alpha;
+            out = input.pos.xyzw;
         }
 
         function fragment (texture :Texture, maxUV :Float2) {

--- a/src/flambe/platform/shader/FillRect.hx
+++ b/src/flambe/platform/shader/FillRect.hx
@@ -4,26 +4,26 @@
 
 package flambe.platform.shader;
 
-import format.hxsl.Shader;
+import hxsl.Shader;
 
 /**
  * Shader that draws solid colored triangles.
  */
-class FillRect extends Shader
+class FillRect extends hxsl.Shader
 {
     static var SRC = {
         var input :{
             pos :Float2,
-            rgb: Float3,
-            alpha: Float,
+            rgb :Float3,
+            alpha :Float,
         };
 
         var _color :Float4;
 
         function vertex () {
-            _color.rgb = rgb*alpha;
-            _color.a = alpha;
-            out = pos.xyzw;
+            _color.rgb = input.rgb*input.alpha;
+            _color.a = input.alpha;
+            out = input.pos.xyzw;
         }
 
         function fragment () {

--- a/tools/waf/flambe.py
+++ b/tools/waf/flambe.py
@@ -52,7 +52,7 @@ def apply_flambe(ctx):
         flags += ["-dce", "full"]
     flags += Utils.to_list(ctx.flags)
 
-    libs = ["format"] + Utils.to_list(ctx.libs)
+    libs = ["hxsl"] + Utils.to_list(ctx.libs)
     platforms = Utils.to_list(ctx.platforms)
     flash_version = ctx.flash_version
     debug = ctx.env.debug


### PR DESCRIPTION
This is definitely not working correctly, but at least it compiles!

Unfortunately I don't know enough about Stage3D to diagnose the issue(s)... as an example, if you create a new flambe project with the following class, the swf has a shaded green square at (0, 0) instead of the desired red square at (100, 100).

``` haxe
import flambe.Entity;
import flambe.System;
import flambe.asset.AssetPack;
import flambe.asset.Manifest;
import flambe.display.FillSprite;

class TestMain
{
    private static function onSuccess (pack :AssetPack)
    {
    }

    private static function main ()
    {
        System.init();
        var sprite = new FillSprite(0xFF0000, 100, 100);
        sprite.x._ = 100;
        sprite.y._ = 100;
        System.root.addChild(new Entity().add(sprite));
    }
}
```
