### PR TITLE
Improve support for embedding multiple instances of Flambe

### DIFF
--- a/src/flambe/platform/html/HtmlExternal.hx
+++ b/src/flambe/platform/html/HtmlExternal.hx
@@ -13,8 +13,9 @@ class HtmlExternal
 {
     public var supported (get, null) :Bool;
 
-    public function new ()
+    public function new (target :Dynamic)
     {
+      _target = target;
     }
 
     public function get_supported ()
@@ -28,12 +29,14 @@ class HtmlExternal
             params = [];
         }
 
-        var method = Reflect.field(Browser.window, name);
+        var method = Reflect.field(_target, name);
         return Reflect.callMethod(null, method, params);
     }
 
     public function bind (name :String, fn :Dynamic)
     {
-        Reflect.setField(Browser.window, name, fn);
+        Reflect.setField(_target, name, fn);
     }
+
+    private var _target :Dynamic;
 }

--- a/src/flambe/platform/html/HtmlPlatform.hx
+++ b/src/flambe/platform/html/HtmlPlatform.hx
@@ -362,7 +362,7 @@ class HtmlPlatform
     public function getExternal () :External
     {
         if (_external == null) {
-            _external = new HtmlExternal();
+            _external = new HtmlExternal(_container);
         }
         return _external;
     }

--- a/src/flambe/platform/html/WebAudioSound.hx
+++ b/src/flambe/platform/html/WebAudioSound.hx
@@ -56,13 +56,15 @@ class WebAudioSound
             var AudioContext = HtmlUtil.loadExtension("AudioContext").value;
 
             if (AudioContext != null) {
-                ctx = untyped __new__(AudioContext);
-                gain = ctx.createGainNode();
-                gain.connect(ctx.destination);
+                try {
+                    ctx = untyped __new__(AudioContext);
+                    gain = ctx.createGainNode();
+                    gain.connect(ctx.destination);
 
-                System.volume.watch(function(volume, _) {
-                    gain.gain.value = volume;
-                });
+                    System.volume.watch(function(volume, _) {
+                        gain.gain.value = volume;
+                    });
+                } catch(e:Dynamic) {}
             }
         }
 


### PR DESCRIPTION
First-pass changes to support multiple Flambe instances on a web page.
- HtmlExternal now binds functions to the embed target, rather than `window`.  This is more consistent with the way it works for Flash and also allows interaction with multiple instances of HTML5 flambe.
- `flambe.embed` can take a callback that is fired when embedding is complete.  This could be used, for example, to embed multiple flambe instances in sequence.
- constructing multiple `AudioContext`s sometimes throws an error (at least on Chrome), so this may now fail silently.
