### PR TITLE
Initial support for shared drawing contexts

### DIFF
--- a/src/flambe/System.hx
+++ b/src/flambe/System.hx
@@ -14,7 +14,9 @@ import flambe.input.Keyboard;
 import flambe.input.Mouse;
 import flambe.input.Pointer;
 import flambe.input.Touch;
+import flambe.platform.Context;
 import flambe.platform.Platform;
+import flambe.platform.Renderer;
 import flambe.storage.Storage;
 import flambe.util.Assert;
 import flambe.util.Logger;
@@ -37,6 +39,11 @@ class System
      * The Stage subsystem, for controlling the display viewport.
      */
     public static var stage (get, null) :Stage;
+
+    /**
+     * A renderer instance from the platform for fine-grained rendering control.
+     */
+    public static var renderer (get, null) :Renderer;
 
     /**
      * The Storage subsystem, for persisting values.
@@ -117,10 +124,10 @@ class System
     /**
      * Starts up Flambe, this should usually be the first thing a game does.
      */
-    public static function init ()
+    public static function init (?context:Context)
     {
         if (!_calledInit) {
-            _platform.init();
+            _platform.init(context);
             _calledInit = true;
         }
     }
@@ -172,6 +179,12 @@ class System
     {
         #if debug assertCalledInit(); #end
         return _platform.getStage();
+    }
+
+    inline private static function get_renderer () :Renderer
+    {
+      #if debug assertCalledInit(); #end
+      return _platform.getRenderer();
     }
 
     inline private static function get_storage () :Storage

--- a/src/flambe/math/Matrix.hx
+++ b/src/flambe/math/Matrix.hx
@@ -91,8 +91,8 @@ class Matrix
         return result;
     }
 
-    public function transformArray (points :ArrayAccess<Float>, length :Int,
-        result :ArrayAccess<Float>)
+    public function transformArray (points :Array<Float>, length :Int,
+        result :Array<Float>)
     {
         var ii = 0;
         while (ii < length) {

--- a/src/flambe/platform/Context.hx
+++ b/src/flambe/platform/Context.hx
@@ -1,0 +1,10 @@
+package flambe.platform;
+
+typedef Context =
+#if flash
+    flambe.platform.flash.Stage3DContext;
+#elseif html
+    flambe.platform.html.CanvasContext;
+#else
+    #error
+#end

--- a/src/flambe/platform/Platform.hx
+++ b/src/flambe/platform/Platform.hx
@@ -21,7 +21,7 @@ import flambe.web.Web;
 
 interface Platform
 {
-    function init () :Void;
+    function init (?context:Context) :Void;
 
     function getKeyboard () :Keyboard;
     function getMouse () :Mouse;

--- a/src/flambe/platform/flash/FlashPlatform.hx
+++ b/src/flambe/platform/flash/FlashPlatform.hx
@@ -45,13 +45,13 @@ class FlashPlatform
     {
     }
 
-    public function init ()
+    public function init (?context:Stage3DContext)
     {
         Log.info("Initializing Flash platform");
 
         var stage = Lib.current.stage;
 
-        _stage = new FlashStage(stage);
+        _stage = new FlashStage(stage, context == null ? false : context.shared);
         _pointer = new BasicPointer();
         _mouse = FlashMouse.shouldUse() ? new FlashMouse(_pointer, stage) : new DummyMouse();
 #if flambe_air
@@ -61,7 +61,8 @@ class FlashPlatform
 #end
         _keyboard = FlashKeyboard.shouldUse() ? new FlashKeyboard(stage) : new DummyKeyboard();
 
-        _renderer = new Stage3DRenderer();
+        _renderer = new Stage3DRenderer(context);
+
         mainLoop = new MainLoop();
 
         stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);

--- a/src/flambe/platform/flash/FlashStage.hx
+++ b/src/flambe/platform/flash/FlashStage.hx
@@ -32,14 +32,16 @@ class FlashStage
 
     public var nativeStage (default, null) :flash.display.Stage;
 
-    public function new (nativeStage :flash.display.Stage)
+    public function new (nativeStage :flash.display.Stage, ?shared = false)
     {
         this.nativeStage = nativeStage;
         resize = new Signal0();
 
-        nativeStage.scaleMode = NO_SCALE;
-        nativeStage.frameRate = 60;
-        nativeStage.showDefaultContextMenu = false;
+        if(!shared) {
+          nativeStage.scaleMode = NO_SCALE;
+          nativeStage.frameRate = 60;
+          nativeStage.showDefaultContextMenu = false;
+        }
         nativeStage.addEventListener(Event.RESIZE, onResize);
 
         fullscreen = new Value<Bool>(false);

--- a/src/flambe/platform/flash/Stage3DBatcher.hx
+++ b/src/flambe/platform/flash/Stage3DBatcher.hx
@@ -26,9 +26,10 @@ class Stage3DBatcher
 {
     public var data (default, null) :Vector<Float>;
 
-    public function new (context3D :Context3D)
+    public function new (context :Stage3DContext)
     {
-        _context3D = context3D;
+        _context3D = context.context3D;
+        _shared = context.shared;
         _drawImageShader = new DrawImage();
         _drawPatternShader = new DrawPattern();
         _fillRectShader = new FillRect();
@@ -49,15 +50,19 @@ class Stage3DBatcher
             _context3D.setRenderToBackBuffer();
             _currentRenderTarget = _lastRenderTarget = null;
         }
-        // And clear it as required by Stage3D
-        _context3D.clear(0, 0, 0);
+
+        if(!_shared) {
+          // And clear it as required by Stage3D
+          _context3D.clear(0, 0, 0);
+        }
     }
 
     public function didRender ()
     {
         // Flush any remaining quads and present the back buffer
         flush();
-        _context3D.present();
+        if(!_shared)
+          _context3D.present();
 
         _lastTexture = null;
         // _lastBlendMode = null;
@@ -343,6 +348,7 @@ class Stage3DBatcher
     private static var _scratchVector3D = new Vector3D();
 
     private var _context3D :Context3D;
+    private var _shared :Bool;
 
     // Used to keep track of context changes requiring a flush
     private var _lastBlendMode :BlendMode;

--- a/src/flambe/platform/flash/Stage3DContext.hx
+++ b/src/flambe/platform/flash/Stage3DContext.hx
@@ -1,0 +1,16 @@
+package flambe.platform.flash;
+
+import flash.display3D.Context3D;
+
+class Stage3DContext
+{
+    public var context3D(default, null):Context3D;
+
+    public var shared(default, null):Bool;
+
+    public function new(context3D:Context3D, ?shared = false)
+    {
+      this.context3D = context3D;
+      this.shared = shared;
+    }
+}

--- a/src/flambe/platform/flash/Stage3DRenderer.hx
+++ b/src/flambe/platform/flash/Stage3DRenderer.hx
@@ -19,51 +19,55 @@ class Stage3DRenderer
 {
     public var batcher (default, null) :Stage3DBatcher;
 
-    public function new ()
+    public function new (?context:Stage3DContext)
     {
-        // Use the first available Stage3D
-        var stage = Lib.current.stage;
-        for (stage3D in stage.stage3Ds) {
-            if (stage3D.context3D == null) {
-                stage.addEventListener(Event.RESIZE, onResize);
+        if(context == null) {
+            // Use the first available Stage3D
+            var stage = Lib.current.stage;
+            for (stage3D in stage.stage3Ds) {
+                if (stage3D.context3D == null) {
+                    stage.addEventListener(Event.RESIZE, onResize);
 
-                stage3D.addEventListener(Event.CONTEXT3D_CREATE, onContext3DCreate);
-                stage3D.addEventListener(ErrorEvent.ERROR, onError);
+                    stage3D.addEventListener(Event.CONTEXT3D_CREATE, onContext3DCreate);
+                    stage3D.addEventListener(ErrorEvent.ERROR, onError);
 
-                // The constrained profile is only available in 11.4
-                if ((untyped stage3D).requestContext3D.length >= 2) {
-                    (untyped stage3D).requestContext3D("auto", "baselineConstrained");
-                } else {
-                    stage3D.requestContext3D();
+                    // The constrained profile is only available in 11.4
+                    if ((untyped stage3D).requestContext3D.length >= 2) {
+                        (untyped stage3D).requestContext3D("auto", "baselineConstrained");
+                    } else {
+                        stage3D.requestContext3D();
+                    }
+                    return;
                 }
-                return;
             }
-        }
 
-        Log.error("No free Stage3Ds available!");
+            Log.error("No free Stage3Ds available!");
+        } else {
+            useContext(context);
+        }
     }
 
     public function createTexture (bitmapData :Dynamic) :Stage3DTexture
     {
-        if (_context3D == null) {
+        if (_context == null) {
             return null; // No Stage3D context yet
         }
 
         var bitmapData :BitmapData = cast bitmapData;
         var texture = new Stage3DTexture(this, bitmapData.width, bitmapData.height);
-        texture.init(_context3D, false);
+        texture.init(_context.context3D, false);
         texture.uploadBitmapData(bitmapData);
         return texture;
     }
 
     public function createEmptyTexture (width :Int, height :Int) :Stage3DTexture
     {
-        if (_context3D == null) {
+        if (_context == null) {
             return null; // No Stage3D context yet
         }
 
         var texture = new Stage3DTexture(this, width, height);
-        texture.init(_context3D, true);
+        texture.init(_context.context3D, true);
         return texture;
     }
 
@@ -95,20 +99,29 @@ class Stage3DRenderer
     private function onContext3DCreate (event :Event)
     {
         var stage3D :Stage3D = event.target;
-        _context3D = stage3D.context3D;
+        useContext(new Stage3DContext(stage3D.context3D, false));
+    }
 
-        Log.info("Created new Stage3D context", ["driver", _context3D.driverInfo]);
+    private function useContext (context:Stage3DContext)
+    {
+      _context = context;
+
+      if(_context.shared) {
+        Log.info("Using shared context", ["driver", _context.context3D.driverInfo]);
 #if flambe_debug_renderer
-        _context3D.enableErrorChecking = true;
+        _context.context3D.enableErrorChecking = true;
 #end
+      } else {
+        Log.info("Using exclusive context", ["driver", _context.context3D.driverInfo]);
+      }
 
-        batcher = new Stage3DBatcher(_context3D);
-        _graphics = createGraphics(null);
-        onResize(null);
+      batcher = new Stage3DBatcher(_context);
+      _graphics = createGraphics(null);
+      onResize(null);
 
-        // Signal that the GPU context was (re)created
-        System.hasGPU._ = false;
-        System.hasGPU._ = true;
+     // Signal that the GPU context was (re)created
+      System.hasGPU._ = false;
+      System.hasGPU._ = true;
     }
 
     private function onError (event :ErrorEvent)
@@ -118,13 +131,13 @@ class Stage3DRenderer
 
     private function onResize (_)
     {
-        if (_context3D != null) {
+        if (_context != null) {
             var stage = Lib.current.stage;
-            _context3D.configureBackBuffer(stage.stageWidth, stage.stageHeight, 2, false);
+            _context.context3D.configureBackBuffer(stage.stageWidth, stage.stageHeight, 2, false);
             _graphics.reset(stage.stageWidth, stage.stageHeight);
         }
     }
 
-    private var _context3D :Context3D;
+    private var _context :Context;
     private var _graphics :Stage3DGraphics;
 }

--- a/src/flambe/platform/html/CanvasContext.hx
+++ b/src/flambe/platform/html/CanvasContext.hx
@@ -1,0 +1,16 @@
+package flambe.platform.html;
+
+import js.html.CanvasElement;
+
+class CanvasContext
+{
+    public var canvas(default, null):CanvasElement;
+
+    public var shared(default, null):Bool;
+
+    public function new(canvas:CanvasElement, ?shared = false)
+    {
+      this.canvas = canvas;
+      this.shared = shared;
+    }
+}

--- a/src/flambe/platform/html/HtmlPlatform.hx
+++ b/src/flambe/platform/html/HtmlPlatform.hx
@@ -41,15 +41,21 @@ class HtmlPlatform
     {
     }
 
-    public function init ()
+    public function init (?context:Context)
     {
         Log.info("Initializing HTML platform");
 
-        var canvas :CanvasElement = null;
-        try {
-            // Use the canvas assigned to us by the flambe.js embedder
-            canvas = (untyped Browser.window).flambe.canvas;
-        } catch (error :Dynamic) {
+        var canvas:CanvasElement = null;
+        if(context == null) {
+          try {
+              // Use the canvas assigned to us by the flambe.js embedder
+              canvas = (untyped Browser.window).flambe.canvas;
+          } catch (error :Dynamic) {
+          }
+        } else {
+          canvas = context.canvas;
+          if(context.shared)
+            Log.warn("Canvas does not support shared context");
         }
         Assert.that(canvas != null,
             "Could not find a Flambe canvas! Are you embedding with flambe.js?");


### PR DESCRIPTION
This should allow flambe to be used together with other frameworks (e.g. Starling) in the same drawing context.
- Allows the chosen platform to be initialised with a specific drawing context (canvas for HTML5, Context3D for Flash)
- Flambe should not perform destructive operations when the drawing context is flagged as shared.
- Exposes the renderer through `System` to allow more fine-grained drawing control.

Currently only the Flash/Stage3D platform uses the shared flag.
