### PR TITLE
Added a method to Texture to get the bounds of an area matching a color

### DIFF
--- a/src/flambe/display/Texture.hx
+++ b/src/flambe/display/Texture.hx
@@ -4,6 +4,8 @@
 
 package flambe.display;
 
+import flambe.math.Rectangle;
+
 import haxe.io.Bytes;
 
 /**
@@ -49,4 +51,21 @@ interface Texture
      * @param pixels A byte buffer in RGBA order.
      */
     function writePixels (pixels :Bytes, x :Int, y :Int, sourceW :Int, sourceH :Int) :Void;
+
+    /**
+     * <p>Determines a rectangular region that fully encloses all pixels of a specified color within
+     * the texture.</p>
+     *
+     * <p>Use mask to specify which values you are interested in (e.g. 0xff000000 = transparency,
+     * 0xff = blue, etc.).  Use the color to specify the color to match.  Pixels whose masked color
+     * does not match the given color will be discounted from the returned area.</p>
+     *
+     * <p>Color values are ARGB.</p>
+     *
+     * @param The mask for extracting values of interest from pixels.
+     * @param The color to search for.
+     * @param Set this to true to find bounds that do not match the color.
+     * @return The bounds of the image matching the color.
+     */
+    function getColorBounds(mask :Int, color :Int, ?negate :Bool) :Rectangle;
 }

--- a/src/flambe/platform/flash/Stage3DTexture.hx
+++ b/src/flambe/platform/flash/Stage3DTexture.hx
@@ -112,6 +112,13 @@ class Stage3DTexture
         }
     }
 
+    public function getColorBounds(mask :Int, color :Int, ?negate = false) :flambe.math.Rectangle
+    {
+        var bitmapData = _renderer.batcher.readPixels(this, 0, 0, width, height);
+        var bounds = bitmapData.getColorBoundsRect(mask, color, !negate);
+        return new flambe.math.Rectangle(bounds.x, bounds.y, bounds.width, bounds.height);
+    }
+
     inline private function get_width () :Int
     {
         return _width;


### PR DESCRIPTION
Behaves similarly to BitmapData#getColorBoundsRect
(http://help.adobe.com/en_US/as2/reference/flashlite/WS5F7E996C-A0F6-4d89-BC17-69622D209F21.html).

For stage3d this uses `getColorBoundsRect`, for HTML5 it will iterate over the raw pixel values.
