### PR TITLE
Detect pointer properly when canvas is scaled by the page

### DIFF
--- a/src/flambe/platform/html/HtmlPlatform.hx
+++ b/src/flambe/platform/html/HtmlPlatform.hx
@@ -391,12 +391,12 @@ class HtmlPlatform
 
     private function getX (event :Dynamic, bounds :Dynamic) :Float
     {
-        return _stage.scaleFactor*(event.clientX - bounds.left);
+        return (event.clientX - bounds.left)*_stage.width/bounds.width;
     }
 
     private function getY (event :Dynamic, bounds :Dynamic) :Float
     {
-        return _stage.scaleFactor*(event.clientY - bounds.top);
+        return (event.clientY - bounds.top)*_stage.height/bounds.height;
     }
 
     private function createRenderer (canvas :CanvasElement) :Renderer


### PR DESCRIPTION
If someone were trying to manually scale the canvas via CSS (i.e. to
fill the window with a flambe_disable_autoresize game), the pointer
coordinates would fail to be scaled to match. This should allow for
arbitrary custom resizing to be applied, and still work with default
situations (including retina compensation).
