### PR TITLE
Beta Zip Loading

### DIFF
--- a/src/flambe/asset/AssetEntry.hx
+++ b/src/flambe/asset/AssetEntry.hx
@@ -22,7 +22,7 @@ enum AssetFormat
     Data;
 	
     // Archived file format
-    ZIP;
+    ZIP; TAR;
 }
 
 /**

--- a/src/flambe/asset/Manifest.hx
+++ b/src/flambe/asset/Manifest.hx
@@ -217,6 +217,7 @@ class Manifest
                 case "opus": return OPUS;
                 case "wav": return WAV;
                 case "zip": return ZIP;
+                case "tar": return TAR;
             }
         } else {
             Log.warn("No file extension for asset, it will be loaded as data", ["url", url]);

--- a/src/flambe/platform/BasicAssetPackLoader.hx
+++ b/src/flambe/platform/BasicAssetPackLoader.hx
@@ -172,9 +172,7 @@ class BasicAssetPackLoader
             map = _pack.textures;
         case MP3, M4A, OPUS, OGG, WAV:
             map = _pack.sounds;
-        case Data:
-            map = _pack.files;
-        case ZIP:
+        case Data, ZIP, TAR:
             map = _pack.files;
         }
 

--- a/src/flambe/platform/flash/FlashAssetPackLoader.hx
+++ b/src/flambe/platform/flash/FlashAssetPackLoader.hx
@@ -23,6 +23,8 @@ import flambe.asset.AssetEntry;
 import flambe.asset.Manifest;
 import flambe.util.Assert;
 
+import format.tar.Data;
+
 import haxe.io.BytesInput;
 import haxe.io.Bytes;
 
@@ -138,8 +140,79 @@ class FlashAssetPackLoader extends BasicAssetPackLoader
                         handleLoad(entryFlambe, asset);						
                     }
                 }
-                handleLoad(entry, {});
             });
+            handleLoad(entry, {});
+            return;
+
+        case TAR:
+            var urlLoader = new URLLoader(req);
+            urlLoader.dataFormat = flash.net.URLLoaderDataFormat.BINARY;
+            dispatcher = urlLoader;
+            var events = new EventGroup();
+            events.addDisposingListener(dispatcher, Event.COMPLETE, function (_) {
+                var bytes = Bytes.ofData(urlLoader.data);
+                var tar = new format.tar.Reader(new BytesInput(bytes));
+                var entries:List<format.tar.Entry> = tar.read();
+
+                for (entry in entries) {					
+                    var extension = entry.fileName.getUrlExtension();  
+                    if(entry.fileName.charAt(0)=="." || entry.fileName.indexOf("/.")>=0) {
+                        extension="";
+                    }
+                    if(extension=="" || extension==null) {
+                        Log.warn("No extension or weird format for tar entry, ignoring this asset", ["url", entry.fileName]);
+                        continue; 
+                    }						
+
+                    _assetsRemaining += 1;	
+                    promise.total += entry.fileSize;	
+
+                    var format = Manifest.inferFormat(entry.fileName);
+                    var name = entry.fileName.removeFileExtension();
+                    if(format == Data) { 
+                        name = entry.fileName;
+                    }					
+                    var entryFlambe = manifest.add(name, entry.fileName, entry.fileSize, format);
+                    var asset;	
+                    var canAdd = false;				
+                    switch(format) {
+                        case JXR, PNG, JPG, GIF:
+                            var loader = new Loader();
+                            loader.loadBytes(entry.data.getData());
+                            var dispatcher:IEventDispatcher = loader.contentLoaderInfo;
+                            var events = new EventGroup();
+                            events.addDisposingListener(dispatcher, Event.COMPLETE, function (_) {
+                                create = function () {
+                                    var bitmap :Bitmap = cast loader.content;
+                                    var texture = _platform.getRenderer().createTexture(bitmap.bitmapData);
+                                    bitmap.bitmapData.dispose();
+                                    return texture;
+                                };
+                                asset = create();
+                                handleLoad(entryFlambe, asset);		
+                            });
+                        case MP3:
+                            var sound = new Sound();
+                            sound.loadCompressedDataFromByteArray(entry.data.getData(), entry.fileSize);
+                            create = function () return new FlashSound(sound);
+                            canAdd = true;
+                        case Data:
+                            create = function () return new BasicFile(entry.data.toString());
+                            canAdd = true;
+                        default:
+							_assetsRemaining -= 1;
+                   			promise.total -= entry.fileSize;
+                            Log.warn("Format not supported for tar entry, ignoring this asset", ["url", entry.fileName]);						
+                            continue;
+                    }					
+		
+                    if (canAdd) {
+                        asset = create();
+                        handleLoad(entryFlambe, asset);						
+                    }
+                }
+            });
+            handleLoad(entry, {});
             return;
 
         default:
@@ -177,6 +250,6 @@ class FlashAssetPackLoader extends BasicAssetPackLoader
 
     override private function getAssetFormats (fn :Array<AssetFormat> -> Void)
     {
-        fn([JXR, PNG, JPG, GIF, MP3, Data, ZIP]);
+        fn([JXR, PNG, JPG, GIF, MP3, Data, ZIP, TAR]);
     }
 }


### PR DESCRIPTION
Manifest can now load zip files.  AssetPackLoader saves each file in
the zip as a blob and loads normally.
- only tested so far with png, jpeg, mp3, ogg, fnt, and xml
- only works if blob is supported
