### PR TITLE
Fix to FlashSound.hx

### DIFF
--- a/src/flambe/platform/flash/FlashSound.hx
+++ b/src/flambe/platform/flash/FlashSound.hx
@@ -121,6 +121,9 @@ private class FlashPlayback
     {
         paused = true;
         _ended = true;
+        //EDIT(Bradley): This must occur to allow garbage collection of sounds.
+        _channel.removeEventListener(Event.SOUND_COMPLETE, onSoundComplete);
+
     }
 
     private function onSoundComplete (_)
@@ -130,8 +133,26 @@ private class FlashPlayback
 
     private function playAudio (startPosition :Float, soundTransform :SoundTransform)
     {
+        _count++;
+
         _channel = _sound.nativeSound.play(startPosition, _loops, soundTransform);
-        _channel.addEventListener(Event.SOUND_COMPLETE, onSoundComplete);
+
+        //Prevent _channel from ever being null, since null can be returned from flash.media.Sound.play() if 
+        //Flash runs out of sound channels. This can (also) happen if many sounds fail to be released from memory.
+        if (_channel == null)
+        {
+            _channel = new SoundChannel();
+
+            //There should be a warning here to notify we have apparently run out of memory for sounds.
+            //Sound will not play when this happens.
+            #if debug
+            trace("Warning: Null sound channel after " + _count + " playAudio calls!");
+            #end
+        }
+
+        //EDIT(Bradley): Use weak listener so sounds can be garbage collected if they never get disposed.
+        _channel.addEventListener(Event.SOUND_COMPLETE, onSoundComplete, false, 0, true);
+        //_channel.addEventListener(Event.SOUND_COMPLETE, onSoundComplete);
         _pausePosition = -1;
         _ended = false;
 
@@ -148,4 +169,7 @@ private class FlashPlayback
     private var _pausePosition :Float;
     private var _ended :Bool;
     private var _tickableAdded :Bool;
+
+    private static var _count:Int;
+
 }


### PR DESCRIPTION
Used weak listener and used removeEventListener on dispose so that sounds can be garbage collected in Flash. This was causing major issues with memory, noticeable in larger games, and resulted in errors after a certain approximate number of sounds played, but not in isolated test cases where the same sounds were being used.

Also instantiated a SoundChannel when the return from flash.media.Sound.play() was null, to avoid errors. Now, in the rare event that Flash runs out of sound channels, they just won't play.
