### PR TITLE
Warnings and cross-domain checking on Data assets.

### DIFF
--- a/src/flambe/asset/Manifest.hx
+++ b/src/flambe/asset/Manifest.hx
@@ -177,9 +177,14 @@ class Manifest
      */
     private function sameDomain(unrestricted :String, restricted :String) :String
     {
+        if (unrestricted == null) {
+            return restricted;
+        }
+
         if (!(unrestricted.startsWith("http://") || unrestricted.startsWith("https://"))) {
             return unrestricted;
         }
+        
         var host = unrestricted.replace("http://","").replace("https://","").split("/")[0];
         return (host == js.Browser.window.location.host) ? unrestricted : restricted;
     }


### PR DESCRIPTION
Adds warning in HTML debug builds when using externalBasePath.
Updated Manifest to allow externalBasePath if using same domain on systems that do not support CORS (Android).
Closes #191
