### PR TITLE
Component updates

### DIFF
--- a/src/flambe/Component.hx
+++ b/src/flambe/Component.hx
@@ -34,6 +34,28 @@ class Component
     public function onAdded ()
     {
     }
+	
+    /**
+     * Called after the owner (Entity) has been added to a parent.
+     */
+    public function onEntityAdded ()
+    {
+    }
+	
+    /**
+     * Called after the owner (Entity) has been removed from its parent.
+     */
+    public function onEntityRemoved ()
+    {
+    }
+
+    /** Called after the owner (Entity) has been added. Using this function the order of adding
+	 * components doesn't matter, all other added components are available.
+	 * When a component is added after the owner is added, this function will also be triggered
+     */
+    public function onStart ()
+    {
+    }
 
     /**
      * Called just before this component has been removed from its entity.
@@ -75,4 +97,6 @@ class Component
     {
         this.next = next;
     }
+	
+	@:allow(flambe) var isStarted(default, null):Bool = false;
 }

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -89,13 +89,12 @@ using Lambda;
 
         component.init(this, null);
         component.onAdded();
-		
-		if (_isStarted && !component.isStarted)
-		{
-			component.onStart();
-			component.isStarted = true;
-		}
-		
+        
+        if (isStarted && !component.isStarted) {
+            component.onStart();
+            component.isStarted = true;
+        }
+        
         return this;
     }
 
@@ -202,18 +201,18 @@ using Lambda;
             firstChild = entity;
         }
 		
-		var child = entity.firstComponent;
-		while (child != null) {
-			var next = child.next;
-			if (!child.isStarted)
-			{
-				child.onStart();
-				child.isStarted = true;
-			}
-			child.onEntityAdded();
-			child = next;
-		}
-		_isStarted = true;
+        var child = entity.firstComponent;
+        while (child != null) {
+            var next = child.next;
+            if (!child.isStarted) {
+                child.onStart();
+                child.isStarted = true;
+            }
+            child.onEntityAdded();
+            child = next;
+        }
+        entity.isStarted = true;
+        
         return this;
     }
 
@@ -237,12 +236,12 @@ using Lambda;
             p = next;
         }
 		
-		var child = entity.firstComponent;
-		while (child != null) {
-			var next = child.next;
-			child.onEntityRemoved();
-			child = next;
-		}
+        var child = entity.firstComponent;
+        while (child != null) {
+            var next = child.next;
+            child.onEntityRemoved();
+            child = next;
+        }
     }
 
     /**
@@ -268,9 +267,8 @@ using Lambda;
         while (firstComponent != null) {
             firstComponent.dispose();
         }
-		
-		_isStarted = false;
-		
+        
+        isStarted = false;
         disposeChildren();
     }
 
@@ -322,5 +320,5 @@ using Lambda;
      * Object/Dictionary for the quickest possible lookups in this critical part of Flambe.
      */
     private var _compMap :Dynamic<Component>;
-	private var _isStarted:Bool = false;
+    private var isStarted:Bool = false;
 }

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -89,7 +89,13 @@ using Lambda;
 
         component.init(this, null);
         component.onAdded();
-
+		
+		if (_isStarted && !component.isStarted)
+		{
+			component.onStart();
+			component.isStarted = false;
+		}
+		
         return this;
     }
 
@@ -195,7 +201,19 @@ using Lambda;
             entity.next = firstChild;
             firstChild = entity;
         }
-
+		
+		var child = entity.firstComponent;
+		while (child != null) {
+			var next = child.next;
+			if (!child.isStarted)
+			{
+				child.onStart();
+				child.isStarted = true;
+			}
+			child.onEntityAdded();
+			child = next;
+		}
+		_isStarted = true;
         return this;
     }
 
@@ -218,6 +236,13 @@ using Lambda;
             prev = p;
             p = next;
         }
+		
+		var child = entity.firstComponent;
+		while (child != null) {
+			var next = child.next;
+			child.onEntityRemoved();
+			child = next;
+		}
     }
 
     /**
@@ -243,6 +268,9 @@ using Lambda;
         while (firstComponent != null) {
             firstComponent.dispose();
         }
+		
+		_isStarted = false;
+		
         disposeChildren();
     }
 
@@ -294,4 +322,5 @@ using Lambda;
      * Object/Dictionary for the quickest possible lookups in this critical part of Flambe.
      */
     private var _compMap :Dynamic<Component>;
+	private var _isStarted:Bool = false;
 }

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -93,7 +93,7 @@ using Lambda;
 		if (_isStarted && !component.isStarted)
 		{
 			component.onStart();
-			component.isStarted = false;
+			component.isStarted = true;
 		}
 		
         return this;

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -230,7 +230,7 @@ using Lambda;
                 }
                 p.parent = null;
                 p.next = null;
-                return;
+                break;
             }
             prev = p;
             p = next;


### PR DESCRIPTION
Provides an essential onStart function for Component, a missing feature of component. It is called once, when the owner (entity) is added or when it is added later to existing Entity. Since this function is called when entity is added, the order of adding components does not matter anymore. 

Also provides onEntityAdded / onEntityRemoved, to make components be able to respond when entity is added/removed/reparented.

Next steps: Should MoviePlayer, MovieSprite, Director use onStart instead of onAdded? The demos should use onStart too.

