### PR TITLE
Tap highlight fix

### DIFF
--- a/command/data/scaffold/web/index.html
+++ b/command/data/scaffold/web/index.html
@@ -37,6 +37,11 @@
       box-shadow: 0px 4px 16px -4px #333;
     }
 
+    canvas {
+      -webkit-tap-highlight-color: rgba(0,0,0,0);
+      -webkit-tap-highlight-color: transparent; /* For some Androids */
+    }
+
     /* On small devices, fill the entire screen and hide the rest of the page. */
     @media (max-device-width: 8in), (max-device-height: 8in) {
       html {


### PR DESCRIPTION
Removes orange/blue highlight on some Android devices with a CSS style.
