### PR TITLE
#197: Adds letterSpacing AnimatedAlpha to TextSprite

### DIFF
--- a/src/flambe/display/Font.hx
+++ b/src/flambe/display/Font.hx
@@ -115,12 +115,12 @@ class Font
         return list;
     }
 
-    public function layoutText (text :String, ?align :TextAlign, wrapWidth :Float = 0) :TextLayout
+    public function layoutText (text :String, ?align :TextAlign, wrapWidth :Float = 0, letterSpacing :Float = 0) :TextLayout
     {
         if (align == null) {
             align = Left;
         }
-        return new TextLayout(this, text, align, wrapWidth);
+        return new TextLayout(this, text, align, wrapWidth, letterSpacing);
     }
 
     /**
@@ -320,7 +320,7 @@ class TextLayout
     /** The number of lines in this text. */
     public var lines (default, null) :Int = 0;
 
-    @:allow(flambe) function new (font :Font, text :String, align :TextAlign, wrapWidth :Float)
+    @:allow(flambe) function new (font :Font, text :String, align :TextAlign, wrapWidth :Float, letterSpacing :Float)
     {
         _font = font;
         _glyphs = [];
@@ -382,7 +382,7 @@ class TextLayout
                 if (glyph.charCode == " ".code) {
                     lastSpaceIdx = ii;
                 }
-                lineWidth += glyph.xAdvance;
+                lineWidth += glyph.xAdvance + letterSpacing;
                 lineHeight = FMath.max(lineHeight, glyph.height + glyph.yOffset);
 
                 // Handle kerning with the next glyph

--- a/src/flambe/display/TextSprite.hx
+++ b/src/flambe/display/TextSprite.hx
@@ -27,6 +27,11 @@ class TextSprite extends Sprite
     public var wrapWidth (default, null) :AnimatedFloat;
 
     /**
+     * The spacing between letters. Defaults to 0
+     */
+    public var letterSpacing (default, null) :AnimatedFloat;
+
+    /**
      * The horizontal text alignment, for multiline text. Left by default.
      */
     public var align (get, set) :TextAlign;
@@ -40,6 +45,9 @@ class TextSprite extends Sprite
         _flags = _flags.add(Sprite.TEXTSPRITE_DIRTY);
 
         wrapWidth = new AnimatedFloat(0, function (_,_) {
+            _flags = _flags.add(Sprite.TEXTSPRITE_DIRTY);
+        });
+        letterSpacing = new AnimatedFloat(0, function (_,_) {
             _flags = _flags.add(Sprite.TEXTSPRITE_DIRTY);
         });
     }
@@ -152,7 +160,7 @@ class TextSprite extends Sprite
         // Recreate the layout if necessary
         if (_flags.contains(Sprite.TEXTSPRITE_DIRTY)) {
             _flags = _flags.remove(Sprite.TEXTSPRITE_DIRTY);
-            _layout = font.layoutText(_text, _align, wrapWidth._);
+            _layout = font.layoutText(_text, _align, wrapWidth._, letterSpacing._);
         }
     }
 
@@ -160,6 +168,7 @@ class TextSprite extends Sprite
     {
         super.onUpdate(dt);
         wrapWidth.update(dt);
+        letterSpacing.update(dt);
     }
 
     private var _font :Font;


### PR DESCRIPTION
I added a new property on TextSprite with the changes on #197, seemed simple enough. The only thing I'm not sure about is that I don't know if `getNaturalWidth()` has to be modified as well. Besides that, this change seems to work great on my tests :).
