### PR TITLE
Added check for negative return values on script Actions that depend on Tween

### DIFF
--- a/src/flambe/script/AnimateBy.hx
+++ b/src/flambe/script/AnimateBy.hx
@@ -33,7 +33,7 @@ class AnimateBy
         if (_value.behavior != _tween) {
             var overtime = _tween.elapsed - _seconds;
             _tween = null;
-            return (overtime > 0) ? dt - overtime : 0;
+            return (overtime > 0) ? Math.max(0, dt - overtime) : 0;
         }
         return -1;
     }

--- a/src/flambe/script/AnimateTo.hx
+++ b/src/flambe/script/AnimateTo.hx
@@ -33,7 +33,7 @@ class AnimateTo
         if (_value.behavior != _tween) {
             var overtime = _tween.elapsed - _seconds;
             _tween = null;
-            return (overtime > 0) ? dt - overtime : 0;
+            return (overtime > 0) ? Math.max(0, dt - overtime) : 0;
         }
         return -1;
     }

--- a/src/flambe/script/MoveBy.hx
+++ b/src/flambe/script/MoveBy.hx
@@ -43,7 +43,7 @@ class MoveBy
             var overtime = FMath.max(_tweenX.elapsed, _tweenY.elapsed) - _seconds;
             _tweenX = null;
             _tweenY = null;
-            return (overtime > 0) ? dt - overtime : 0;
+            return (overtime > 0) ? Math.max(0, dt - overtime) : 0;
         }
         return -1;
     }

--- a/src/flambe/script/MoveTo.hx
+++ b/src/flambe/script/MoveTo.hx
@@ -43,7 +43,7 @@ class MoveTo
             var overtime = FMath.max(_tweenX.elapsed, _tweenY.elapsed) - _seconds;
             _tweenX = null;
             _tweenY = null;
-            return (overtime > 0) ? dt - overtime : 0;
+            return (overtime > 0) ? Math.max(0, dt - overtime) : 0;
         }
         return -1;
     }


### PR DESCRIPTION
Tween could finish in different frame with different delta time so overtime can be bigger than this frame's delta time. Negative return value would cause action not to end and next update it would create another tween.
