### PR TITLE
added <requestedDisplayResolution> tag in Adobe Air descriptor

### DIFF
--- a/command/index.js
+++ b/command/index.js
@@ -280,6 +280,7 @@ exports.build = function (config, platforms, opts) {
             "    <Entitlements><![CDATA[\n" +
                    get(config, "ios Entitlements.plist", "") +
             "    ]]></Entitlements>\n" +
+            "    <requestedDisplayResolution>high</requestedDisplayResolution>\n" +
             "  </iPhone>\n" +
             "</application>";
         var doc = new xmldom.DOMParser().parseFromString(xml);


### PR DESCRIPTION
Adding this will automatically enable high resolution for retina screens on iOS, make games look great. Without this, it looks blurry and unreadable.
