### PR TITLE
Change System.init to return a promise to cope with asynchronous platform initialization

### DIFF
--- a/src/flambe/System.hx
+++ b/src/flambe/System.hx
@@ -122,14 +122,20 @@ class System
     public static var volume (default, null) :AnimatedFloat = new AnimatedFloat(1);
 
     /**
+    * Used to indicate whether asynchronous platform initialization has finished
+    */
+    public static var promise (default, null) :Promise<Bool>;
+
+    /**
      * Starts up Flambe, this should usually be the first thing a game does.
      */
     public static function init ()
     {
         if (!_calledInit) {
-            _platform.init();
+            promise = _platform.init();
             _calledInit = true;
         }
+        return promise;
     }
 
     /**

--- a/src/flambe/platform/Platform.hx
+++ b/src/flambe/platform/Platform.hx
@@ -13,7 +13,7 @@ import flambe.util.Promise;
 
 interface Platform
 {
-    function init () :Void;
+    function init () :Promise<Bool>;
 
     function getExternal () :ExternalSystem;
     function getKeyboard () :KeyboardSystem;

--- a/src/flambe/platform/flash/FlashPlatform.hx
+++ b/src/flambe/platform/flash/FlashPlatform.hx
@@ -37,6 +37,10 @@ class FlashPlatform
     public function init ()
     {
         var stage = Lib.current.stage;
+        var promise = new Promise<Bool>();
+        promise.success.connect(function (result) {
+            Log.info("Initialized Flash platform", ["renderer", _renderer.type]);
+        });
 
         _stage = new FlashStage(stage);
         _pointer = new BasicPointer();
@@ -47,7 +51,12 @@ class FlashPlatform
         _touch = new DummyTouch();
 #end
 
-        _renderer = new Stage3DRenderer();
+        var stage3DRenderer = new Stage3DRenderer();
+        _renderer = stage3DRenderer;
+        stage3DRenderer.promise.success.connect(function (result) {
+            // Stage3DRenderer's initialization is the only asynchronous part of FlashPlatform's init
+            promise.result = result;
+        });
         mainLoop = new MainLoop();
 
         stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);
@@ -96,7 +105,7 @@ class FlashPlatform
         new DebugLogic(this);
         _catapult = FlashCatapultClient.canUse() ? new FlashCatapultClient() : null;
 #end
-        Log.info("Initialized Flash platform", ["renderer", _renderer.type]);
+        return promise;
     }
 
     public function loadAssetPack (manifest :Manifest) :Promise<AssetPack>

--- a/src/flambe/platform/flash/Stage3DRenderer.hx
+++ b/src/flambe/platform/flash/Stage3DRenderer.hx
@@ -18,6 +18,7 @@ import flambe.display.Graphics;
 import flambe.display.Texture;
 import flambe.subsystem.RendererSystem;
 import flambe.util.Assert;
+import flambe.util.Promise;
 import flambe.util.Value;
 
 class Stage3DRenderer
@@ -31,9 +32,15 @@ class Stage3DRenderer
 
     public var batcher (default, null) :Stage3DBatcher;
 
+    /**
+    * Used to indicate whether a Context3D has been created yet, as this is the only asynchronous point of Flash init
+    */
+    public var promise : Promise<Bool>;
+
     public function new ()
     {
         _hasGPU = new Value<Bool>(false);
+        promise = new Promise<Bool>();
 
         // Use the first available Stage3D
         var stage = Lib.current.stage;
@@ -144,6 +151,12 @@ class Stage3DRenderer
         // Signal that the GPU context was (re)created
         hasGPU._ = false;
         hasGPU._ = true;
+
+        // initialization of the Renderer has completed if a Context3D has been created
+        if (!promise.hasResult)
+        {
+            promise.result = true;
+        }
     }
 
     private function onError (event :ErrorEvent)

--- a/src/flambe/platform/html/HtmlPlatform.hx
+++ b/src/flambe/platform/html/HtmlPlatform.hx
@@ -266,7 +266,12 @@ class HtmlPlatform
         _catapult = HtmlCatapultClient.canUse() ? new HtmlCatapultClient() : null;
 #end
 #end
-        Log.info("Initialized HTML platform", ["renderer", _renderer.type]);
+        var promise = new Promise<Bool>();
+        promise.success.connect(function (result) {
+            Log.info("Initialized HTML platform", ["renderer", _renderer.type]);
+        });
+        promise.result = true;
+        return promise;
     }
 
     public function loadAssetPack (manifest :Manifest) :Promise<AssetPack>


### PR DESCRIPTION
FlashPlatform's initialization is actually asynchronous, in that we must wait for Stage3DRenderer to acquire a Context3D before we're ready to roll. Since the Flash platform requires a Context3D before textures can be loaded, quickly loading textures after calling System.init was causing undesirable behavior (null textures), due to a Context3D not yet being available. With this change, we can wait for a platform to become ready before continuing with other work.
