### PR TITLE
added <supportedLanguages> tag in Adobe Air descriptor

### DIFF
--- a/command/index.js
+++ b/command/index.js
@@ -261,6 +261,7 @@ exports.build = function (config, platforms, opts) {
             "  <id>"+get(config, "id")+"</id>\n" +
             "  <versionNumber>"+get(config, "version")+"</versionNumber>\n" +
             "  <filename>"+get(config, "name")+"</filename>\n" +
+            "  <supportedLanguages>" + get(config, "supported_languages", "en") + "</supportedLanguages>\n" +
             "  <initialWindow>\n" +
             "    <content>"+swf+"</content>\n" +
             "    <aspectRatio>"+get(config, "orientation", "portrait")+"</aspectRatio>\n" +


### PR DESCRIPTION
iTunes lists around 15 different languages when user does not provide this <supportedLanguages> tag. Now it defaults to "en", and is optional configurable in the _flambe.yaml_ file ("supported_languages" setting)

Reference: 
http://help.adobe.com/en_US/air/build/WSfffb011ac560372f2fea1812938a6e463-8000.html#WS06ac295d95cf5a5c-4601cdc2134337a7308-8000