### PR TITLE
Disabling pixelsnapping breaks game on some MovieSprites.

### DIFF
--- a/src/flambe/swf/MovieSprite.hx
+++ b/src/flambe/swf/MovieSprite.hx
@@ -333,8 +333,10 @@ private class LayerAnimator
 
     public function setPixelSnapping (pixelSnapping :Bool) :Void
     {
-        for (sprite in _sprites) {
-            sprite.pixelSnapping = pixelSnapping;
+        if (_sprites != null) {        
+            for (sprite in _sprites) {
+                sprite.pixelSnapping = pixelSnapping;
+            }
         }
     }
 


### PR DESCRIPTION
Just need to make sure the _sprites array exists before looping. This is related to #242
