### PR TITLE
Conditionals for disabling smoothing & texture filtering

### DIFF
--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -95,6 +95,44 @@ using flambe.util.BitSets;
 
         return this;
     }
+	
+	 /**
+     * Add a component to this entity and make it first one to update. Any previous component of this type will be replaced.
+     * @returns This instance, for chaining.
+     */
+    public function addFirst (component :Component) :Entity
+	{
+		 // Remove the component from any previous owner. Don't just call dispose, which has
+        // additional behavior in some components (like Disposer).
+        if (component.owner != null) {
+            component.owner.remove(component);
+        }
+
+        var name = component.name;
+        var prev = getComponent(name);
+        if (prev != null) {
+            // Remove the previous component under this name
+            remove(prev);
+        }
+
+        untyped _compMap[name] = component;
+
+        
+		if (firstComponent == null)
+		{
+			firstComponent = component;
+			component.next = null;			
+		} else 
+		{			
+			component.next = firstComponent;
+			firstComponent = component;
+		}
+
+        component.owner = this;
+        component.onAdded();
+
+        return this;
+	}
 
     /**
      * Remove a component from this entity.

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -265,6 +265,13 @@ using flambe.util.BitSets;
             p = next;
         }
     }
+	
+	public function setParent(entity:Entity):Entity
+	{
+		entity.addChild(this);
+		
+		return this;
+	}
 
     /**
      * Dispose all of this entity's children, without touching its own components or removing itself

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -282,7 +282,7 @@ using flambe.util.BitSets;
 
         return this;
     }
-
+	
     public function removeChild (entity :Entity)
     {
         var prev :Entity = null, p = firstChild;
@@ -304,10 +304,10 @@ using flambe.util.BitSets;
         }
     }
 	
-	public function setParent(entity:Entity):Entity
+	public function setParent(entity:Entity, append:Bool = true):Entity
 	{
 		if (entity != null)
-			entity.addChild(this)
+			entity.addChild(this, append)
 		else if (this.parent != null)
 			this.parent.removeChild(this);
 		

--- a/src/flambe/Entity.hx
+++ b/src/flambe/Entity.hx
@@ -268,7 +268,10 @@ using flambe.util.BitSets;
 	
 	public function setParent(entity:Entity):Entity
 	{
-		entity.addChild(this);
+		if (entity != null)
+			entity.addChild(this)
+		else if (this.parent != null)
+			this.parent.removeChild(this);
 		
 		return this;
 	}

--- a/src/flambe/platform/MainLoop.hx
+++ b/src/flambe/platform/MainLoop.hx
@@ -52,7 +52,7 @@ class MainLoop
         }
 
         System.volume.update(dt);
-
+		
         updateEntity(System.root, dt);
     }
 
@@ -104,7 +104,7 @@ class MainLoop
                 p._flags = p._flags.add(Component.STARTED);
                 p.onStart();
             }
-            p.onUpdate(dt);
+            p.onUpdate(dt);			
             p = next;
         }
 
@@ -112,7 +112,7 @@ class MainLoop
         var p = entity.firstChild;
         while (p != null) {
             var next = p.next;
-            updateEntity(p, dt);
+            updateEntity(p, dt);						
             p = next;
         }
     }

--- a/src/flambe/platform/MainLoop.hx
+++ b/src/flambe/platform/MainLoop.hx
@@ -39,7 +39,6 @@ class MainLoop
             // huge deltaTimes, but not all environments support detecting an unpause
             dt = 1;
         }
-
         // First update any tickables, folding away nulls
         var ii = 0;
         while (ii < _tickables.length) {
@@ -52,7 +51,7 @@ class MainLoop
         }
 
         System.volume.update(dt);
-		
+
         updateEntity(System.root, dt);
     }
 

--- a/src/flambe/platform/html/CanvasGraphics.hx
+++ b/src/flambe/platform/html/CanvasGraphics.hx
@@ -18,7 +18,15 @@ class CanvasGraphics
 {
     public function new (canvas :CanvasElement, alpha :Bool)
     {
-        _canvasCtx = (untyped canvas).getContext("2d", {alpha: alpha});
+        _canvasCtx = (untyped canvas).getContext("2d", { alpha: alpha } );
+		
+					
+		#if flambe_canvas_disable_smoothing
+			(untyped _canvasCtx).webkitImageSmoothingEnabled = false;
+			(untyped _canvasCtx).oImageSmoothingEnabled = false;
+			(untyped _canvasCtx).mozImageSmoothingEnabled = false;
+			_canvasCtx.imageSmoothingEnabled = false;
+		#end
     }
 
     public function save ()

--- a/src/flambe/platform/html/HtmlUtil.hx
+++ b/src/flambe/platform/html/HtmlUtil.hx
@@ -139,9 +139,17 @@ class HtmlUtil
     public static function createCanvas (source :CanvasElement) :CanvasElement
     {
         var canvas = createEmptyCanvas(source.width, source.height);
-
+		
         var ctx = canvas.getContext2d();
-        ctx.save();
+				
+		#if flambe_canvas_disable_smoothing
+			(untyped ctx).webkitImageSmoothingEnabled = false;
+			(untyped ctx).oImageSmoothingEnabled = false;
+			(untyped ctx).mozImageSmoothingEnabled = false;
+			ctx.imageSmoothingEnabled = false;
+		#end
+		
+        ctx.save();		
         ctx.globalCompositeOperation = "copy";
         ctx.drawImage(source, 0, 0);
         ctx.restore();

--- a/src/flambe/platform/html/WebGLTextureRoot.hx
+++ b/src/flambe/platform/html/WebGLTextureRoot.hx
@@ -36,14 +36,21 @@ class WebGLTextureRoot extends BasicAsset<WebGLTextureRoot>
         renderer.batcher.bindTexture(nativeTexture);
         gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
         gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
-        gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
-    #if flambe_webgl_enable_mipmapping
-        gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR_MIPMAP_NEAREST);
-    #elseif flambe_webgl_enable_linear
-        gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
-    #else
-        gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
-    #end
+		
+	#if flambe_webgl_force_nearest
+        gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+		gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+	#else
+		#if flambe_webgl_enable_mipmapping
+			gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR_MIPMAP_NEAREST);
+		#elseif flambe_webgl_enable_linear
+			gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+		#else
+			gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+		#end
+	#end
+		
+   
     }
 
     public function createTexture (width :Int, height :Int) :WebGLTexture
@@ -66,7 +73,7 @@ class WebGLTextureRoot extends BasicAsset<WebGLTextureRoot>
         _renderer.batcher.bindTexture(nativeTexture);
         var gl = _renderer.gl;
         gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, image);
-    #if flambe_webgl_enable_mipmapping
+    #if flambe_webgl_enable_mipmapping && !flambe_webgl_force_nearest
         gl.generateMipmap(GL.TEXTURE_2D);
     #end
     }
@@ -78,7 +85,7 @@ class WebGLTextureRoot extends BasicAsset<WebGLTextureRoot>
         _renderer.batcher.bindTexture(nativeTexture);
         var gl = _renderer.gl;
         gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
-    #if flambe_webgl_enable_mipmapping
+    #if flambe_webgl_enable_mipmapping && !flambe_webgl_force_nearest
         gl.generateMipmap(GL.TEXTURE_2D);
     #end
     }

--- a/src/flambe/platform/shader/DrawPattern.hx
+++ b/src/flambe/platform/shader/DrawPattern.hx
@@ -27,9 +27,14 @@ class DrawPattern extends Shader
             out = input.pos.xyzw;
         }
 
-        function fragment (texture :Texture, region :Float4) {
-            // region is weirdly ordered to workaround a Windows bug
-            out = texture.get(region.zw + _uv%region.xy, clamp) * _alpha;
+        function fragment (texture :Texture, region :Float4) {           
+			#if flambe_stage3d_force_nearest
+				// region is weirdly ordered to workaround a Windows bug
+				out = texture.get(region.zw + _uv % region.xy, clamp, nearest) * _alpha;
+			#else
+				// region is weirdly ordered to workaround a Windows bug
+				out = texture.get(region.zw + _uv % region.xy, clamp) * _alpha;
+			#end
         }
     }
 }

--- a/src/flambe/platform/shader/DrawTexture.hx
+++ b/src/flambe/platform/shader/DrawTexture.hx
@@ -28,7 +28,11 @@ class DrawTexture extends Shader
         }
 
         function fragment (texture :Texture) {
-            out = texture.get(_uv, clamp) * _alpha;
+			#if flambe_stage3d_force_nearest
+				out = texture.get(_uv, clamp, nearest) * _alpha;
+			#else
+				out = texture.get(_uv, clamp) * _alpha;
+			#end
         }
     }
 }

--- a/src/flambe/script/Script.hx
+++ b/src/flambe/script/Script.hx
@@ -35,7 +35,7 @@ class Script extends Component
     {
         _handles = [];
     }
-
+	
     override public function onUpdate (dt :Float)
     {
         var ii = 0;

--- a/src/flambe/script/Script.hx
+++ b/src/flambe/script/Script.hx
@@ -36,6 +36,12 @@ class Script extends Component
         _handles = [];
     }
 	
+	public var empty(get, null):Bool;
+	inline function get_empty():Bool
+	{
+		return _handles.length == 0;
+	}
+	
     override public function onUpdate (dt :Float)
     {
         var ii = 0;


### PR DESCRIPTION
So now you can turn off smoothing / anti-aliasing / filtering (sets it to nearest) individually for each platform.
<code>
-D flambe_webgl_force_nearest 
-D flambe_stage3d_force_nearest
-D flambe_canvas_disable_smoothing
</code>

<b>Take into account that with
<code>
-D flambe_webgl_force_nearest 
</code>
flambe will ignore 
<code>
-D flambe_webgl_enable_mipmapping
-D flambe_webgl_enable_linear
</code></b>