### PR TITLE
Cache rotation calculation in Sprite, skip skew math in MovieSprite in many situations.

### DIFF
--- a/src/flambe/display/Sprite.hx
+++ b/src/flambe/display/Sprite.hx
@@ -302,7 +302,7 @@ class Sprite extends Component
         if (_flags.contains(LOCAL_MATRIX_DIRTY)) {
             _flags = _flags.remove(LOCAL_MATRIX_DIRTY);
 
-            if(_flags.contains(ROTATION_DIRTY)) {            
+            if(_flags.contains(ROTATION_DIRTY)) {
                 _flags = _flags.remove(ROTATION_DIRTY);
                 var rotation :Float = FMath.toRadians(this.rotation._);
                 _sinCache = Math.sin(rotation);

--- a/src/flambe/display/Sprite.hx
+++ b/src/flambe/display/Sprite.hx
@@ -122,7 +122,7 @@ class Sprite extends Component
 
     public function new ()
     {
-        _flags = _flags.add(VISIBLE | POINTER_ENABLED | VIEW_MATRIX_DIRTY | PIXEL_SNAPPING);
+        _flags = _flags.add(VISIBLE | POINTER_ENABLED | VIEW_MATRIX_DIRTY | PIXEL_SNAPPING | ROTATION_DIRTY);
         _localMatrix = new Matrix();
 
         var dirtyMatrix = function (_,_) {
@@ -130,7 +130,9 @@ class Sprite extends Component
         };
         x = new AnimatedFloat(0, dirtyMatrix);
         y = new AnimatedFloat(0, dirtyMatrix);
-        rotation = new AnimatedFloat(0, dirtyMatrix);
+        rotation = new AnimatedFloat(0, function(_,_) {
+            _flags = _flags.add(LOCAL_MATRIX_DIRTY | VIEW_MATRIX_DIRTY | ROTATION_DIRTY);
+        });
         scaleX = new AnimatedFloat(1, dirtyMatrix);
         scaleY = new AnimatedFloat(1, dirtyMatrix);
         anchorX = new AnimatedFloat(0, dirtyMatrix);
@@ -299,8 +301,19 @@ class Sprite extends Component
     {
         if (_flags.contains(LOCAL_MATRIX_DIRTY)) {
             _flags = _flags.remove(LOCAL_MATRIX_DIRTY);
+            var rotation :Float = this.rotation._;
+            var x :Float = this.x._;
+            var y :Float = this.y._;
+            var scaleX :Float = this.scaleX._;
+            var scaleY :Float = this.scaleY._;
 
-            _localMatrix.compose(x._, y._, scaleX._, scaleY._, FMath.toRadians(rotation._));
+            if(_flags.contains(ROTATION_DIRTY)) {            
+                _flags = _flags.remove(ROTATION_DIRTY);
+                _sinCache = Math.sin(rotation);
+                _cosCache = Math.cos(rotation);
+            }
+
+            _localMatrix.set(_cosCache*scaleX, _sinCache*scaleX, -_sinCache*scaleY, _cosCache*scaleY, x, y);
             _localMatrix.translate(-anchorX._, -anchorY._);
         }
         return _localMatrix;
@@ -727,14 +740,17 @@ class Sprite extends Component
     private static inline var VIEW_MATRIX_DIRTY = Component.NEXT_FLAG << 3;
     private static inline var PIXEL_SNAPPING = Component.NEXT_FLAG << 4;
     private static inline var HOVERING = Component.NEXT_FLAG << 5;
-    private static inline var NEXT_FLAG = Component.NEXT_FLAG << 6; // Must be last!
+    private static inline var ROTATION_DIRTY = Component.NEXT_FLAG << 6;
+    private static inline var NEXT_FLAG = Component.NEXT_FLAG << 7; // Must be last!
 
     private var _localMatrix :Matrix;
 
     private var _viewMatrix :Matrix = null;
     private var _viewMatrixUpdateCount :Int = 0;
     private var _parentViewMatrixUpdateCount :Int = 0;
-
+    private var _sinCache :Float = 0;
+    private var _cosCache :Float = 0;
+#if debug private var _savedRotations :Int = 0; #end
     private var _pointerDown :Signal1<PointerEvent>;
     private var _pointerMove :Signal1<PointerEvent>;
     private var _pointerUp :Signal1<PointerEvent>;

--- a/src/flambe/display/Sprite.hx
+++ b/src/flambe/display/Sprite.hx
@@ -304,7 +304,7 @@ class Sprite extends Component
 
             if(_flags.contains(ROTATION_DIRTY)) {            
                 _flags = _flags.remove(ROTATION_DIRTY);
-                var rotation :Float = this.rotation._;
+                var rotation :Float = FMath.toRadians(this.rotation._);
                 _sinCache = Math.sin(rotation);
                 _cosCache = Math.cos(rotation);
             }

--- a/src/flambe/display/Sprite.hx
+++ b/src/flambe/display/Sprite.hx
@@ -750,7 +750,6 @@ class Sprite extends Component
     private var _parentViewMatrixUpdateCount :Int = 0;
     private var _sinCache :Float = 0;
     private var _cosCache :Float = 0;
-#if debug private var _savedRotations :Int = 0; #end
     private var _pointerDown :Signal1<PointerEvent>;
     private var _pointerMove :Signal1<PointerEvent>;
     private var _pointerUp :Signal1<PointerEvent>;

--- a/src/flambe/display/Sprite.hx
+++ b/src/flambe/display/Sprite.hx
@@ -301,19 +301,17 @@ class Sprite extends Component
     {
         if (_flags.contains(LOCAL_MATRIX_DIRTY)) {
             _flags = _flags.remove(LOCAL_MATRIX_DIRTY);
-            var rotation :Float = this.rotation._;
-            var x :Float = this.x._;
-            var y :Float = this.y._;
-            var scaleX :Float = this.scaleX._;
-            var scaleY :Float = this.scaleY._;
 
             if(_flags.contains(ROTATION_DIRTY)) {            
                 _flags = _flags.remove(ROTATION_DIRTY);
+                var rotation :Float = this.rotation._;
                 _sinCache = Math.sin(rotation);
                 _cosCache = Math.cos(rotation);
             }
 
-            _localMatrix.set(_cosCache*scaleX, _sinCache*scaleX, -_sinCache*scaleY, _cosCache*scaleY, x, y);
+            var scaleX :Float = this.scaleX._;
+            var scaleY :Float = this.scaleY._;
+            _localMatrix.set(_cosCache*scaleX, _sinCache*scaleX, -_sinCache*scaleY, _cosCache*scaleY, x._, y._);
             _localMatrix.translate(-anchorX._, -anchorY._);
         }
         return _localMatrix;

--- a/src/flambe/swf/MovieSprite.hx
+++ b/src/flambe/swf/MovieSprite.hx
@@ -321,8 +321,16 @@ private class LayerAnimator
 
         // From an identity matrix, append the translation, skew, and scale
         var matrix = sprite.getLocalMatrix();
-        var sinX = Math.sin(skewX), cosX = Math.cos(skewX);
-        var sinY = Math.sin(skewY), cosY = Math.cos(skewY);
+        var sinX = 0.0, cosX = 1.0;
+        var sinY = 0.0, cosY = 1.0;
+        if (skewX != 0) {
+            sinX = Math.sin(skewX);
+            cosX = Math.cos(skewX);
+        }
+        if (skewY != 0) {
+            sinY = Math.sin(skewY);
+            cosY = Math.cos(skewY);
+        }
         matrix.set(cosY*scaleX, sinY*scaleX, -sinX*scaleY, cosX*scaleY, x, y);
 
         // Append the pivot


### PR DESCRIPTION
Since most Sprites aren't constantly rotating, only calculate the sine and cosine math for rotation when the rotation changes (Inspired by the PixiJS renderer). Also skip doing the skew math on MovieSprites if there is no skew, which is the case many times.