### PR TITLE
Optimization for Stage3DBatcher ...

### DIFF
--- a/src/flambe/platform/flash/Stage3DBatcher.hx
+++ b/src/flambe/platform/flash/Stage3DBatcher.hx
@@ -182,10 +182,10 @@ class Stage3DBatcher
     public function prepareDrawTexture (renderTarget :Stage3DTextureRoot,
         blendMode :BlendMode, scissor :Rectangle, texture :Stage3DTexture) :Int
     {
-        if (texture != _lastTexture) {
+        if (_lastTexture == null || texture.root != _lastTexture.root) {
             flush();
-            _lastTexture = texture;
         }
+        _lastTexture = texture;
         return prepareQuad(5, renderTarget, blendMode, scissor, _drawTextureShader);
     }
 
@@ -193,10 +193,10 @@ class Stage3DBatcher
     public function prepareDrawPattern (renderTarget :Stage3DTextureRoot,
         blendMode :BlendMode, scissor :Rectangle, texture :Stage3DTexture) :Int
     {
-        if (texture != _lastTexture) {
+        if (_lastTexture == null || texture.root != _lastTexture.root) {
             flush();
-            _lastTexture = texture;
         }
+        _lastTexture = texture;
         return prepareQuad(5, renderTarget, blendMode, scissor, _drawPatternShader);
     }
 


### PR DESCRIPTION
I believe this should fix #314. I've created a stress using 2000 animated MovieSprites. With these changes I'm getting a solid 60FPS. Without the changes, I top out at about 20FPS. Hopefully this doesn't introduce any weird bugs, but so far it's been solid for me on my projects.

The stress test demo I'm using can be downloaded here:
http://clients.seven2.com/out/batcher-stress-test.zip