### PR TITLE
Fixed some slight type changes with the Haxe 3.2 nightlies.

### DIFF
--- a/src/flambe/platform/html/CanvasTextureRoot.hx
+++ b/src/flambe/platform/html/CanvasTextureRoot.hx
@@ -8,6 +8,7 @@ import js.Browser;
 import js.html.*;
 
 import haxe.io.Bytes;
+import haxe.io.BytesData;
 
 import flambe.display.Graphics;
 import flambe.display.Texture;
@@ -40,8 +41,7 @@ class CanvasTextureRoot extends BasicAsset<CanvasTextureRoot>
     {
         assertNotDisposed();
 
-        var data :Array<Int> = cast getContext2d().getImageData(x, y, width, height).data;
-        return Bytes.ofData(data);
+        return Bytes.ofData(cast getContext2d().getImageData(x, y, width, height).data);
     }
 
     public function writePixels (pixels :Bytes, x :Int, y :Int, sourceW :Int, sourceH :Int)

--- a/src/flambe/platform/html/HtmlAssetPackLoader.hx
+++ b/src/flambe/platform/html/HtmlAssetPackLoader.hx
@@ -202,7 +202,7 @@ class HtmlAssetPackLoader extends BasicAssetPackLoader
             }
             xhr = new XMLHttpRequest();
             xhr.open("GET", url, true);
-            xhr.responseType = responseType;
+            untyped xhr.responseType = responseType;
 
             var lastProgress = 0.0;
             xhr.onprogress = function (event :ProgressEvent) {
@@ -361,10 +361,11 @@ class HtmlAssetPackLoader extends BasicAssetPackLoader
             // request so it's all good.
             xhr.open("GET", ".", true);
 
-            if (xhr.responseType != "") {
+            if (untyped xhr.responseType != "") {
                 return false; // No responseType supported at all
             }
-            xhr.responseType = "blob";
+
+            untyped xhr.responseType = "blob"; // Using untyped to prevent problems going between haxe 3.1 to haxe 3.2
             if (xhr.responseType != "blob") {
                 return false; // Blob responseType not supported
             }

--- a/src/flambe/platform/html/HtmlAssetPackLoader.hx
+++ b/src/flambe/platform/html/HtmlAssetPackLoader.hx
@@ -366,7 +366,7 @@ class HtmlAssetPackLoader extends BasicAssetPackLoader
             }
 
             untyped xhr.responseType = "blob"; // Using untyped to prevent problems going between haxe 3.1 to haxe 3.2
-            if (xhr.responseType != "blob") {
+            if (untyped xhr.responseType != "blob") {
                 return false; // Blob responseType not supported
             }
 


### PR DESCRIPTION
This shouldn't cause any problems if you're running Haxe 3.1.3 stable because I just made the slight API changes "untyped." I know it's a little sloppy, so if you have a different idea on how you'd like to handle it I can revise.