### PR TITLE
Convenient functions to avoid using the underscore for most cases

### DIFF
--- a/src/flambe/animation/AnimatedFloat.hx
+++ b/src/flambe/animation/AnimatedFloat.hx
@@ -79,6 +79,30 @@ class AnimatedFloat extends Value<Float>
         behavior = new Tween(_value, _value + by, seconds, easing);
     }
 
+    inline public function substract(v :Float) :AnimatedFloat
+    {
+        _ -= v;
+        return this;
+    }
+
+    inline public function add(v :Float) :AnimatedFloat
+    {
+        _ += v;
+        return this;
+    }
+    
+    inline public function multiplyBy(by :Float) :AnimatedFloat
+    {
+        _ *= by;
+        return this;
+    }
+
+    inline public function devideBy(by :Float) :AnimatedFloat
+    {
+        _ /= by;
+        return this;
+    }
+
     inline public function bindTo (to :Value<Float>, ?fn :BindingFunction)
     {
         behavior = new Binding(to, fn);


### PR DESCRIPTION
I think 
```haxe
owner.get(Sprite).scaleX.multiplyBy(1.4);
```
Looks slightly better than
```haxe
owner.get(Sprite).scaleX._ *= 1.4;
```
In ideal case AnimatedFloat is an abstract so you can do `enityA.get(Sprite).scaleX * enityB.get(Sprite).scaleX` and maybe we don't need to deal with the underscore, ever.