### PR TITLE
Fixes for haxe 3.2 release

### DIFF
--- a/src/flambe/platform/html/HtmlAssetPackLoader.hx
+++ b/src/flambe/platform/html/HtmlAssetPackLoader.hx
@@ -155,20 +155,20 @@ class HtmlAssetPackLoader extends BasicAssetPackLoader
 
     inline private function downloadArrayBuffer (url :String, entry :AssetEntry, onLoad :ArrayBuffer -> Void)
     {
-        download(url, entry, "arraybuffer", onLoad);
+        download(url, entry, ARRAYBUFFER, onLoad);
     }
 
     inline private function downloadBlob (url :String, entry :AssetEntry, onLoad :Blob -> Void)
     {
-        download(url, entry, "blob", onLoad);
+        download(url, entry, BLOB, onLoad);
     }
 
     inline private function downloadText (url :String, entry :AssetEntry, onLoad :String -> Void)
     {
-        download(url, entry, "text", onLoad);
+        download(url, entry, TEXT, onLoad);
     }
 
-    private function download (url :String, entry :AssetEntry, responseType :String, onLoad :Dynamic -> Void)
+    private function download (url :String, entry :AssetEntry, responseType :XMLHttpRequestResponseType, onLoad :Dynamic -> Void)
     {
         var xhr :XMLHttpRequest = null;
         var start = null;
@@ -202,7 +202,7 @@ class HtmlAssetPackLoader extends BasicAssetPackLoader
             }
             xhr = new XMLHttpRequest();
             xhr.open("GET", url, true);
-            untyped xhr.responseType = responseType;
+            xhr.responseType = responseType;
 
             var lastProgress = 0.0;
             xhr.onprogress = function (event :ProgressEvent) {
@@ -361,12 +361,11 @@ class HtmlAssetPackLoader extends BasicAssetPackLoader
             // request so it's all good.
             xhr.open("GET", ".", true);
 
-            if (untyped xhr.responseType != "") {
+            if (xhr.responseType != NONE) {
                 return false; // No responseType supported at all
             }
-
-            untyped xhr.responseType = "blob"; // Using untyped to prevent problems going between haxe 3.1 to haxe 3.2
-            if (untyped xhr.responseType != "blob") {
+            xhr.responseType = BLOB;
+            if (xhr.responseType != BLOB) {
                 return false; // Blob responseType not supported
             }
 


### PR DESCRIPTION
Haxe 3.2 has just been released which is causing javascript builds to fail. After fixing the errors myself I released that somebody had already done it at https://github.com/aduros/flambe/commit/ec084011873cf16635f4e2a77cc0d2dc6c58625d

Although reading that commit left me wondering if, as there is a XMLHttpRequestResponseType enum that is returned by the ```xhr.responseType```field, it might be safer to use that than label the variables as untyped. 

If not feel free to close this!

Also by any chance do you have an ETA on when the latest version of Flambe will be pushed to haxelib?

Cheers!

