### PR TITLE
remove no-opt and no-inline

### DIFF
--- a/command/index.js
+++ b/command/index.js
@@ -482,7 +482,7 @@ exports.build = function (config, platforms, opts) {
         });
         commonFlags.push("-dce", "full");
         if (debug) {
-            commonFlags.push("-debug", "--no-opt", "--no-inline");
+            commonFlags.push("-debug");
         } else {
             commonFlags.push("--no-traces");
         }


### PR DESCRIPTION
It's very useful (even when debugging) to see how the inlines/optimalisations from Haxe work.