### PR TITLE
`Value.watch` should return `SignalConnection`

### DIFF
--- a/src/flambe/util/Value.hx
+++ b/src/flambe/util/Value.hx
@@ -35,7 +35,7 @@ class Value<A>
      * Immediately calls a listener with the current value, and again whenever the value changes.
      * @returns A handle that can be disposed to stop watching for changes.
      */
-    public function watch (listener :Listener2<A,A>) :Disposable
+    public function watch (listener :Listener2<A,A>) :SignalConnection
     {
         listener(_value, _value);
         return changed.connect(listener);


### PR DESCRIPTION
because `Signal2.connect` also returns `SignalConnection`